### PR TITLE
Fix for Cannot read property `measure` of null

### DIFF
--- a/lib/CoreKeyboardAwareView.js
+++ b/lib/CoreKeyboardAwareView.js
@@ -44,6 +44,7 @@ class CoreKeyboardAwareView extends React.Component {
     this.debugLog(e);
 
     requestAnimationFrame(() => {
+      if (this.outerView == null) return;
       this.outerView.measure((ox, oy, width, height, px, py) => {
         this.debugLog(ox, oy, px, py);
         // target scrollView height should be :


### PR DESCRIPTION
We are having random crash for this null exception. Can you please merge this?
