### PR TITLE
Split `react` and `react-native` imports for RN 0.25.1

### DIFF
--- a/lib/CoreKeyboardAwareView.js
+++ b/lib/CoreKeyboardAwareView.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
 var {
     Dimensions,
     Animated,
     View,
     ScrollView,
     DeviceEventEmitter,
-    } = React;
+    } = require('react-native');
 var {width, height} = Dimensions.get('window');
 import dismissKeyboard from 'react-native/Libraries/Utilities/dismissKeyboard'
 


### PR DESCRIPTION
[React Native 0.25.1 starts showing a deprecation warning](https://stackoverflow.com/questions/37052798/reactnative-createclass-is-deprecated-use-react-createclass-from-react-package) when you import general React stuff (things not specific to React Native, like `createElement`, `Component`, etc.) from the `react-native` package.
