### PR TITLE
added useNativeDriver to Animation.timing to avoid warnings

### DIFF
--- a/lib/CoreKeyboardAwareView.js
+++ b/lib/CoreKeyboardAwareView.js
@@ -63,6 +63,7 @@ class CoreKeyboardAwareView extends React.Component {
             {
               toValue: maxHeight,
               duration: this.props.animated ? 200 : 0,
+              useNativeDriver: false
             }
         ).start();
 
@@ -100,6 +101,7 @@ class CoreKeyboardAwareView extends React.Component {
             {
               toValue: maxHeight,
               duration: this.props.animated ? 200 : 0,
+              useNativeDriver: false
             }
         ).start();
 
@@ -121,6 +123,7 @@ class CoreKeyboardAwareView extends React.Component {
                 {
                   toValue: height,
                   duration: 0,
+                  useNativeDriver: false
                 }
               ).start();
 


### PR DESCRIPTION
To avoid warnings in react we need to add useNativeDriver to Animation.timing.